### PR TITLE
Add bridge link to demo repo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GitHub Actions Cert Prep
 
+[![GitHub Actions Certification - Demo Repo](https://img.shields.io/badge/GitHub_Actions_Certification-Course_Repo-blue?logo=github&logoColor=white)](https://github.com/timothywarner-org/nodejs-demoapp)
+
 [![Check Links](https://github.com/timothywarner/actions-cert-prep/actions/workflows/links.yml/badge.svg?branch=main&event=workflow_dispatch)](https://github.com/timothywarner/actions-cert-prep/actions/workflows/links.yml)
 
 ## Contact info


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a new badge to indicate that this is a demo repository for GitHub Actions Certification.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R4): Added a badge linking to the GitHub Actions Certification demo repository.