### PR TITLE
Fixed the shields.io badge again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Actions Cert Prep
 
-[![GitHub Actions Certification - Demo Repo](https://img.shields.io/badge/GitHub_Actions_Certification-Demo_Repo-blue?logo=github&logoColor=white)]([https://github.com/timothywarner-org/nodejs-demoapp](https://github.com/timothywarner/nodejs-demoapp))
+[![GitHub Actions Certification - Demo Repo](https://img.shields.io/badge/GitHub_Actions_Certification-Demo_Repo-blue?logo=github&logoColor=white)](https://github.com/timothywarner/nodejs-demoapp)
 
 [![Check Links](https://github.com/timothywarner/actions-cert-prep/actions/workflows/links.yml/badge.svg?branch=main&event=workflow_dispatch)](https://github.com/timothywarner/actions-cert-prep/actions/workflows/links.yml)
 


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change corrects the URL for the GitHub Actions Certification demo repository badge.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Fixed the URL for the GitHub Actions Certification demo repository badge.